### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repository ships **managers, overrides, and a small amount of commit-messag
 
 ```jsonc
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>home-operations/renovate-presets"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>home-operations/renovate-presets"],
 }
 ```
 
@@ -23,7 +23,7 @@ Use Renovate's path-based preset syntax (include the `.json5` extension since Re
 
 ```jsonc
 {
-    "extends": ["github>home-operations/renovate-presets//managers/cnpg.json5"],
+  "extends": ["github>home-operations/renovate-presets//managers/cnpg.json5"],
 }
 ```
 


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented with the repo's pinned oxfmt.