### PR TITLE
feat(grafanaDashboards): support grafana-operator GrafanaDashboard structured fields

### DIFF
--- a/managers/grafanaDashboards.json5
+++ b/managers/grafanaDashboards.json5
@@ -13,13 +13,56 @@
     {
       description: "Process Grafana dashboards",
       customType: "regex",
-      managerFilePatterns: ["/grafanadashboard\\.yaml(?:\\.j2)?$/"],
+      managerFilePatterns: ["/grafanadashboard\\.ya?ml(?:\\.j2)?$/"],
       matchStrings: [
         "dashboards\\/(?<depName>\\d+)\\/revisions\\/(?<currentValue>\\d+)\\/download",
       ],
       datasourceTemplate: "custom.grafana-dashboards",
       versioningTemplate: "regex:^(?<major>\\d+)$",
       autoReplaceStringTemplate: "dashboards/{{depName}}/revisions/{{newValue}}/download",
+    },
+    {
+      // grafana-operator's GrafanaDashboard CR expresses the same dependency as structured
+      // `spec.grafanaCom.{id,revision}` fields instead of a download URL. Everything between the
+      // two keys is captured in `gap` and replayed verbatim, so blank lines and comments survive
+      // the update, inline ones included.
+      //
+      // Both keys must sit at the same indent or the match would escape the mapping and rewrite an
+      // unrelated `revision:` further up the document. Renovate compiles match strings with RE2,
+      // which has no backreferences, so the indent cannot be captured and compared back; instead
+      // one match string per common indent width repeats that width literally on both key lines.
+      // YAML forbids tabs for indentation, so only spaces need covering, and a manifest indented
+      // some other way is simply left untracked, which is the safe way to fail.
+      //
+      // Key order is handled by a second manager below rather than more match strings, because the
+      // replacement template has to emit the keys in the order it matched them.
+      description: "Process Grafana dashboards in grafana-operator GrafanaDashboard CRs",
+      customType: "regex",
+      managerFilePatterns: ["/grafanadashboard\\.ya?ml(?:\\.j2)?$/"],
+      matchStrings: [
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {2})id:\\s*(?<depName>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {2})revision:\\s*(?<currentValue>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {4})id:\\s*(?<depName>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {4})revision:\\s*(?<currentValue>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {6})id:\\s*(?<depName>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {6})revision:\\s*(?<currentValue>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {8})id:\\s*(?<depName>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {8})revision:\\s*(?<currentValue>\\d+)",
+      ],
+      datasourceTemplate: "custom.grafana-dashboards",
+      versioningTemplate: "regex:^(?<major>\\d+)$",
+      autoReplaceStringTemplate: "grafanaCom:{{{pad}}}\n{{{indent}}}id: {{{depName}}}{{{gap}}}revision: {{{newValue}}}",
+    },
+    {
+      // Same as above with the keys reversed (revision before id).
+      description: "Process Grafana dashboards in grafana-operator GrafanaDashboard CRs (reversed key order)",
+      customType: "regex",
+      managerFilePatterns: ["/grafanadashboard\\.ya?ml(?:\\.j2)?$/"],
+      matchStrings: [
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {2})revision:\\s*(?<currentValue>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {2})id:\\s*(?<depName>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {4})revision:\\s*(?<currentValue>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {4})id:\\s*(?<depName>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {6})revision:\\s*(?<currentValue>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {6})id:\\s*(?<depName>\\d+)",
+        "grafanaCom:(?<pad>[^\\n]*)\\n(?<indent> {8})revision:\\s*(?<currentValue>\\d+)(?<gap>[ \\t]*(?:#[^\\n]*)?(?:\\n[ \\t]*(?:#[^\\n]*)?)*?\\n {8})id:\\s*(?<depName>\\d+)",
+      ],
+      datasourceTemplate: "custom.grafana-dashboards",
+      versioningTemplate: "regex:^(?<major>\\d+)$",
+      autoReplaceStringTemplate: "grafanaCom:{{{pad}}}\n{{{indent}}}revision: {{{newValue}}}{{{gap}}}id: {{{depName}}}",
     },
   ],
   packageRules: [


### PR DESCRIPTION
Closes #53.

The existing manager matches `dashboards/<id>/revisions/<n>/download` URLs, but grafana-operator's `GrafanaDashboard` CR pins the same thing as structured fields:

```yaml
spec:
  grafanaCom:
    id: 12345
    revision: 7
```

Adds a manager for that, reusing the existing `custom.grafana-dashboards` datasource. Separate manager rather than another match string because the replace template differs. It captures the child indentation so the rewrite keeps the manifest's own nesting, handles either key order, and both managers now match `.yml` as well as `.yaml`.

Tested with `renovate --platform=local --dry-run=extract`; passes `renovate-config-validator --strict` and `oxfmt`.