### PR TITLE
ci: skip release-please version-bump PRs in checks

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,6 +19,9 @@ concurrency:
 
 jobs:
   validate:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Guards the check jobs so only **genuine release-please PRs** are skipped, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

The earlier `startsWith(github.head_ref, ...)`-only form was unsafe: `head_ref` is the PR's source branch name, which anyone can set - including from a fork - so a PR from a `release-please--*` branch would skip every check. Requiring the PR head repo to be this repo means fork PRs (the realistic path for outside contributors) always run the full suite. Ordinary PRs, pushes to `main`, and `workflow_dispatch` are unaffected.

Part of an org-wide CI conformity / minutes pass.
