### PR TITLE
fix: raise a pull request before automerging

### DIFF
--- a/config/baseConfig.json5
+++ b/config/baseConfig.json5
@@ -5,7 +5,7 @@
     "config:recommended",
     "docker:enableMajor",
     "helpers:pinGitHubActionDigestsToSemver",
-    ":automergeBranch",
+    ":automergePr",
     ":dependencyDashboard",
     ":disableRateLimiting",
   ],


### PR DESCRIPTION
## Overview

Swaps `:automergeBranch` for `:automergePr` in `config/baseConfig.json5`.

## Additional information

`:automergeBranch` is `{"automergeType": "branch"}` — when a rule sets
`automerge: true`, Renovate pushes the commit straight to the base branch with
**no pull request**.

Unlike home-operations/renovate-config#39, where the preset is currently inert,
**this repo is actually affected**. Its own `.renovaterc.json5` extends:

```json5
":automergeMinor",   // automerge: true for minor, patch, pin, lockFileMaintenance
":automergeDigest",  // automerge: true for digest
```

so those update types have `automerge: true` while inheriting `automergeType:
branch` from `config/baseConfig.json5` — i.e. they are eligible to land on `main`
without a pull request.

`validate.yaml` only runs on `pull_request` and pushes to `main`, so a Renovate
branch carries no status checks for branch automerge to gate on either way.

Validated with `renovate-config-validator --strict` against all 19 files.
Regenerating `default.json` produces no diff, since it is a list of preset file
references rather than inlined content.

> [!NOTE]
> CI on this branch will be red for the same pre-existing reason as
> home-operations/renovate-presets#62 — mise `2026.7.13` rejects
> `npm:renovate@43.280.1` on a supply-chain trust check during `Setup Mise`.
> That has been failing on `main` since before this branch existed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.