### PR TITLE
fix(mise): allow the @yarnpkg/libzip trust downgrade

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -3,7 +3,13 @@
 lefthook = "2.1.10"
 node = "26.5.0"
 oxfmt = "0.60.0"
-"npm:renovate" = "43.280.1"
+# @yarnpkg/libzip 3.2.2 shipped without provenance where 3.2.0 had it, so mise's
+# no-downgrade trust policy refuses the whole tree. It reaches us through
+# @yarnpkg/core, which requires ^3.2.2 — the floor, so no renovate version can
+# resolve past it. Drop the exclude once upstream publishes an attested release.
+"npm:renovate" = { version = "43.280.1", trust_policy_excludes = [
+  "@yarnpkg/libzip",
+] }
 shellcheck = "0.11.0"
 zizmor = "1.28.0"
 

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -82,6 +82,9 @@ url = "https://nodejs.org/dist/v26.5.0/node-v26.5.0-win-x64.zip"
 version = "43.280.1"
 backend = "npm:renovate"
 
+[tools."npm:renovate".options]
+trust_policy_excludes = '["@yarnpkg/libzip"]'
+
 [[tools.oxfmt]]
 version = "0.60.0"
 backend = "npm:oxfmt"


### PR DESCRIPTION
## Overview

Unblocks CI, which has been red on `main` since 2026-07-25T14:04.

mise `2026.7.13` added a supply-chain trust check that refuses the entire renovate
dependency tree during `Setup Mise`, before any workflow logic runs:

```
mise ERROR Failed to install npm:renovate@43.280.1: aube install failed: failed to resolve dependencies
  caused by: trust downgrade for @yarnpkg/libzip@3.2.2 (trustPolicy=no-downgrade):
  earlier published version 3.2.0 had provenance attestation but this version has no trust evidence
```

## Why rolling renovate back does not fix it

`@yarnpkg/libzip` is not a direct dependency. It arrives via `@yarnpkg/core`, and
the requirement is a **floor**:

| package | requires |
|---|---|
| `@yarnpkg/core` 4.7.0 / 4.8.0 / 4.9.0 | `@yarnpkg/libzip: ^3.2.2` |
| `renovate` 43.270.0 … 43.280.5 | `@yarnpkg/core: 4.9.0` (exact) |

`^3.2.2` cannot resolve to 3.2.0 or 3.2.1, so no pin in that band avoids the
flagged version. Escaping it would mean going back past `@yarnpkg/core` 4.7.0 —
and Renovate would immediately propose bumping it again.

## The fix

`trust_policy_excludes` is mise's own escape hatch, suggested verbatim in the
error. It is scoped to the single flagged package, so every other dependency in
the tree stays checked.

Renovate keeps bumping the pin despite the table form — its mise manager reads
`.version` out of an object (`parseVersion`, `modules/manager/mise/extract.js`),
and has a matching `parseOptions` for the extra key.

`mise.lock` gains the corresponding `[tools."npm:renovate".options]` entry.

## Verification

Reproduced and fixed against mise `2026.7.13` specifically (the version CI uses;
local was `2026.7.11`, which predates the check), with a cold `MISE_DATA_DIR` so
nothing was served from cache:

| config | exit |
|---|---|
| `"npm:renovate" = "43.280.1"` | **1** — the error above, byte-for-byte |
| `+ trust_policy_excludes = ["@yarnpkg/libzip"]` | **0** |

`mise run lint` and `renovate-config-validator --strict` (19 files) both pass
locally.

Once this is green, this repo can take the `Build Success` required status check
alongside the rest of the org.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — the investigation, change and this description were written by an AI agent (Claude Code) under maintainer direction.
