### PR TITLE
fix(talosFactory): ignore factory.talos.dev images matched by generic managers

### DIFF
--- a/managers/talosFactory.json5
+++ b/managers/talosFactory.json5
@@ -27,6 +27,12 @@
   ],
   packageRules: [
     {
+      description: "Ignore factory.talos.dev images matched by generic managers; the custom manager above owns them",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/^factory\\.talos\\.dev\\//"],
+      enabled: false,
+    },
+    {
       matchDatasources: ["custom.talos-factory"],
       semanticCommitScope: "container",
       commitMessageTopic: "{{depName}}",


### PR DESCRIPTION
The kubernetes manager (extended to scan `.yaml.j2` files by the file-pattern preset) also extracts `factory.talos.dev` installer image lines as docker dependencies, alongside the custom manager that already owns them. With a templated schematic this fails lookup and leaves a permanent warning on the dependency dashboard; with a plain schematic it can produce duplicate update PRs. Disable docker-datasource matches on these images so only the `custom.talos-factory` path handles them.