### PR TITLE
fix(cnpg): split image name on the last colon, not the first

### DIFF
--- a/managers/cnpg.json5
+++ b/managers/cnpg.json5
@@ -7,11 +7,31 @@
       // which is specific enough that false positives are rare in practice. If your repo has
       // unrelated YAML with `imageName:` or `reference:` followed by an image-like string,
       // override `managerFilePatterns` to scope this preset to your CNPG manifests.
+      //
+      // `depName` excludes `@` and `currentValue` excludes `/` so that the name/tag split lands
+      // on the LAST colon, which is the only one that introduces a tag. Both exclusions matter:
+      //
+      //   registry.local:5000/foo/bar:1.2.3   without the `/` exclusion this splits on the port
+      //                                       colon -> depName `registry.local`, currentValue
+      //                                       `5000/foo/bar:1.2.3`
+      //   ghcr.io/foo/bar@sha256:<64 hex>     without the `@` exclusion depName captures greedily
+      //                                       past the `@` -> `ghcr.io/foo/bar@sha256`, and the
+      //                                       digest is read as the version. Renovate then looks
+      //                                       up a package that cannot exist and reports it as a
+      //                                       lookup failure, which reads like a private-registry
+      //                                       or credentials problem rather than a parse one.
+      //
+      // Digest-only references are deliberately NOT matched. Such a reference carries no tag, so
+      // there is nothing to say WHICH line should be tracked — Renovate's kustomize manager
+      // resolves that ambiguity by assuming `:latest`, but versioned extension images frequently
+      // publish no `latest` at all, and guessing it in a shared preset would propose updates
+      // across an unrelated release line. Write `name:tag@digest` to keep a digest pin AND be
+      // explicit about what is tracked; that form is matched, with the digest captured below.
       description: "Detect CNPG Cluster CRD imageName + extension reference fields",
       customType: "regex",
       managerFilePatterns: ["/.+\\.ya?ml(?:\\.j2)?$/"],
       matchStrings: [
-        "(?:imageName|reference):\\s+(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
+        "(?:imageName|reference):\\s+(?<depName>[^@\\s]+):(?<currentValue>[^@\\s/]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
       ],
       datasourceTemplate: "docker",
     },


### PR DESCRIPTION
## Problem

The Cluster `imageName` / extension `reference` matcher captures `depName` with `[^:\s]+`, which stops at the **first** colon. Two reference shapes mis-parse as a result.

**Digest-only** — `ghcr.io/foo/bar@sha256:<64 hex>`:

```
depName      ghcr.io/foo/bar@sha256      <- @sha256 swallowed
currentValue <the 64 hex digits>         <- digest read as the version
```

Renovate then looks up a package that cannot exist, and reports it as a package lookup failure:

```
Failed to look up docker package ghcr.io/foo/bar@sha256: no-result
```

That reads like a private-registry or credentials problem, which is where I spent my time before spotting it was a parse bug. The tell is the `@sha256` sitting *inside* the reported package name.

**Registry with an explicit port** — `registry.local:5000/foo/bar:1.2.3`:

```
depName      registry.local
currentValue 5000/foo/bar:1.2.3
```

I found this one while validating the first fix; it's the same wrong-colon root cause.

## Fix

Exclude `@` from `depName` and `/` from `currentValue`, which moves the split to the **last** colon — the only one that introduces a tag:

```diff
-(?<depName>[^:\s]+):(?<currentValue>[^@\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?
+(?<depName>[^@\s]+):(?<currentValue>[^@\s/]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?
```

## Behaviour by shape

Verified against Go's `regexp` — RE2, the same engine Renovate compiles custom managers with. **The two shapes that work today are unchanged:**

| reference | before | after |
|---|---|---|
| `ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie` | ✅ `postgresql` @ `18.4-standard-trixie` | ✅ unchanged |
| `ghcr.io/cloudnative-pg/pgvector:0.8.0@sha256:…` | ✅ `pgvector` @ `0.8.0` + digest | ✅ unchanged |
| `ghcr.io/foo/bar@sha256:…` | ❌ `ghcr.io/foo/bar@sha256` @ `<hex>` | ✅ no match (skipped) |
| `registry.local:5000/foo/bar:1.2.3` | ❌ `registry.local` @ `5000/foo/bar:1.2.3` | ✅ `registry.local:5000/foo/bar` @ `1.2.3` |

No lookarounds or backreferences are introduced, so the pattern stays RE2-compatible — confirmed by compiling it with Go's `regexp` rather than only a PCRE engine.

## Why digest-only is skipped rather than supported

Deliberate, and noted in the preset so it isn't re-litigated from the regex alone.

A digest-only reference carries no tag, so there is nothing in the text to say **which line** should be tracked. The kustomize manager resolves that ambiguity by fiat (`without a version, digests are tracked as :latest`), but versioned CNPG extension images frequently publish no `latest` at all — the image that led me here has tags `2`, `2.29`, `2.29.0`, `rolling`, `sandbox` and nothing else. Assuming `latest` in a shared preset would therefore either fail the lookup again or propose updates across an unrelated release line.

`name:tag@digest` keeps a digest pin *and* states the tracked line explicitly, and is matched today — that seems like the better thing to steer people toward. Happy to add digest-only support with `currentValueTemplate: "latest"` if you'd prefer it; it needs an `autoReplaceStringTemplate` override too, or the first update silently rewrites a digest-only ref into `name:latest@sha256:…`.

## Validation

- `mise run lint` — clean
- `mise run validate default.json managers/*.json5 overrides/*.json5 versioning/*.json5 .renovaterc.json5` — 14 files validated successfully
- `default.json` only references preset paths, so no regeneration needed

Found via a CNPG TimescaleDB ImageVolume extension pinned by bare digest, where this surfaced as the only entry under "Repository Problems" on the dependency dashboard.
