### PR TITLE
feat(policies)!: treat zer0ver 0.x minors as breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Shareable [Renovate](https://docs.renovatebot.com) custom managers and package overrides for the Kubernetes / homelab ecosystem.
 
-This repository ships **managers, overrides, and a small amount of commit-message policy** — no opinionated `packageRules` for grouping, automerging, or scheduling. Extend what you need; keep your own policy local.
+This repository ships **managers, overrides, and a small amount of update policy** (commit messages, zer0ver handling) — no opinionated `packageRules` for grouping, automerging, or scheduling. Extend what you need; keep your own policy local.
 
 ## Usage
 
@@ -40,7 +40,7 @@ Presets are grouped by intent. Each file is self-documenting — open it for the
 - [`config/`](./config) — top-level Renovate config (registry aliases, built-in manager file-pattern extensions).
 - [`managers/`](./managers) — custom regex and datasource managers that pick up dependencies Renovate's built-in managers miss.
 - [`overrides/`](./overrides) — fixes to `depName`, `sourceUrl`, `packageName`, or `changelogUrl` for specific packages or managers.
-- [`policies/`](./policies) — opt-in `packageRules` that shape commit messages. Extend only if you want the convention.
+- [`policies/`](./policies) — opt-in `packageRules` for conventions: commit-message shaping and zer0ver (0.x minors treated as breaking). Extend only if you want the convention.
 - [`versioning/`](./versioning) — custom `versioning` schemes for upstreams that ship non-semver tags.
 
 [`default.json`](./default.json) lists every preset that ships in this repo.

--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
     "github>home-operations/renovate-presets//overrides/mise.json5",
     "github>home-operations/renovate-presets//overrides/renovateOperator.json5",
     "github>home-operations/renovate-presets//policies/semanticCommits.json5",
+    "github>home-operations/renovate-presets//policies/zer0ver.json5",
     "github>home-operations/renovate-presets//versioning/llamacpp.json5",
     "github>home-operations/renovate-presets//versioning/phanpy.json5",
     "github>home-operations/renovate-presets//versioning/searxng.json5"

--- a/policies/zer0ver.json5
+++ b/policies/zer0ver.json5
@@ -1,0 +1,26 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    // SemVer gives 0.x releases no stability guarantee, so treat their minors
+    // like majors. Repo packageRules concatenate after presets: if you
+    // automerge minors, add your own matchCurrentVersion: "!/^v?0/" guard —
+    // a guard shipped here would just be overridden by your rule.
+    {
+      description: "zer0ver: 0.x minors can break at any time, give them the breaking `!` prefix",
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      semanticCommitType: "feat",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
+      commitMessageExtra: "({{currentVersion}} ➔ {{newVersion}})",
+    },
+    // The default branchName template includes additionalBranchPrefix, so this
+    // lands 0.x minors on the same major-<groupSlug> branch Renovate uses to
+    // split grouped majors; ungrouped deps just get a major- branch rename.
+    {
+      description: "zer0ver: 0.x minors can break at any time, route them onto the major branches",
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      additionalBranchPrefix: "major-",
+    },
+  ],
+}


### PR DESCRIPTION
Adds `policies/zer0ver.json5`, wired into `default.json` (regenerated via `mise run gen`). SemVer gives 0.x releases no stability guarantee, and Renovate [deliberately classifies](https://github.com/renovatebot/renovate/discussions/30925) `0.x → 0.y` as minor, so this preset makes those updates visible as what they are:

- **Breaking commit prefix**: 0.x minors get `feat(scope)!:`, consistent with how this repo's `semanticCommits` policy already marks majors.
- **Major branch routing**: `additionalBranchPrefix: "major-"` lands 0.x minors on the same `major-<groupSlug>` branch Renovate uses to split grouped majors (the default `branchName` template is `{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}`), so they stop sharing group PRs with safe patches. Ungrouped deps just get a `major-` branch rename.

Intentionally not included:

- **Labels** - this repo ships no label policy, and zer0ver shouldn't introduce one.
- **An automerge guard** - repo `packageRules` concatenate after presets, so a consumer's automerge-minors rule would override any guard shipped here. The preset documents the `matchCurrentVersion: "!/^v?0/"` guard consumers should add themselves.

Proven out in home-operations/renovate-config#64; see home-operations/tuppr#482 for the routing in action.

BREAKING CHANGE: consumers of the bare preset get breaking commit prefixes for 0.x minors, and every open 0.x-minor PR is closed and reopened once under a `major-` branch. Extend `policies/zer0ver.json5` individually (or pin a pre-2.0 tag) to opt in/out explicitly.