### PR TITLE
fix(default): scope helm-values manager to values and helmrelease files

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,8 @@
   "description": [
     "Stock Renovate presets that form the base of this bundle. Listed alphabetically first so subsequent presets in this repo can override.",
     "Brand the Renovate dependency dashboard issue with a distinctive title so it's easy to spot among other issues.",
-    "Extend the built-in flux, helm-values, and kubernetes managers to also scan Jinja-templated YAML (`.yaml.j2` / `.yml.j2`).",
+    "Extend the built-in flux and kubernetes managers to also scan Jinja-templated YAML (`.yaml.j2` / `.yml.j2`).",
+    "Scope the helm-values manager to values and Flux HelmRelease files (plus their `.j2` variants) so bare `image:` lines elsewhere aren't double-extracted alongside the kubernetes manager, which inflates grouped-update counts (e.g. `minimumGroupSize`).",
     "Resolve `mirror.gcr.io` references against Docker Hub so Renovate finds tags and digests via the upstream registry.",
     "Extend every general-purpose preset in this repo. App-specific presets under apps/ are opt-in."
   ],
@@ -23,7 +24,8 @@
   },
   "helm-values": {
     "managerFilePatterns": [
-      "/\\.ya?ml(?:\\.j2)?$/"
+      "/(^|/)values\\.ya?ml(?:\\.j2)?$/",
+      "/(^|/)helmrelease\\.ya?ml(?:\\.j2)?$/"
     ]
   },
   "helmfile": {

--- a/default.json
+++ b/default.json
@@ -25,7 +25,8 @@
   "helm-values": {
     "managerFilePatterns": [
       "/(^|/)values\\.ya?ml(?:\\.j2)?$/",
-      "/(^|/)helmrelease\\.ya?ml(?:\\.j2)?$/"
+      "/(^|/)helmrelease\\.ya?ml(?:\\.j2)?$/",
+      "/(^|/)hr\\.ya?ml(?:\\.j2)?$/"
     ]
   },
   "helmfile": {


### PR DESCRIPTION
## The problem

The bundle broadens both the `helm-values` and `kubernetes` managers to every YAML file (`/\.ya?ml(?:\.j2)?$/`). Any bare `image: <ref>:<tag>` line in a matched file is therefore extracted **twice** — once per manager. Renovate tolerates the duplicate at commit time (the second upgrade logs `Cannot find replaceString in current file content. Was it already updated?` and no-ops), but the duplicates land in `branchConfig.upgrades`, and `minimumGroupSize` compares against that raw length.

Observed in onedr0p/home-ops: a kubernetes group gated with `minimumGroupSize: 5` (4 control-plane images + the tuppr kubelet pin) was released by onedr0p/home-ops#11550 with only 4 unique deps updated — each was flattened twice (`14 flattened updates found: ... kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler`), so 8 ≥ 5 and the branch was created without waiting for kubelet. Every `minimumGroupSize` consumer of this bundle is affected the same way.

## The fix

`helm-values` exists for values documents (`repository:`/`tag:` pairs and image refs inside chart values); scanning all YAML with it is what creates the systemic overlap. Scope it to:

- `/(^|/)values\.ya?ml(?:\.j2)?$/` — the manager's stock default, plus the `.j2` variant
- `/(^|/)helmrelease\.ya?ml(?:\.j2)?$/` and `/(^|/)hr\.ya?ml(?:\.j2)?$/` — Flux HelmRelease inline values, both common file naming conventions

The `kubernetes` manager stays on all YAML and keeps covering full `image:` lines everywhere else (Talos machineconfigs, CRs, etc.).

Verified against the home-ops extraction dump from the affected run: all 29 deps that only `helm-values` provides live in `helmrelease.yaml` files and stay covered; the 7 double-extracted sites drop to single extraction (the Talos `.j2` files and an EnvoyProxy CR move to the `kubernetes` manager alone; the runner HelmReleases keep a benign overlap since their values embed a pod-spec-style `containers[].image`).

Consumers with helm values images in YAML files named something other than `values.yaml`/`helmrelease.yaml` would lose those updates — flagging in case other repos rely on the broad match.
