### PR TITLE
feat(default): match helm-release.yaml in the helm-values manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,6 +26,7 @@
     "managerFilePatterns": [
       "/(^|/)values\\.ya?ml(?:\\.j2)?$/",
       "/(^|/)helmrelease\\.ya?ml(?:\\.j2)?$/",
+      "/(^|/)helm-release\\.ya?ml(?:\\.j2)?$/",
       "/(^|/)hr\\.ya?ml(?:\\.j2)?$/"
     ]
   },


### PR DESCRIPTION
Some repos name their Flux HelmRelease manifests `helm-release.yaml` rather than `helmrelease.yaml` or `hr.yaml`. Since #97 scoped the `helm-values` manager to an explicit file list, those files are no longer scanned by it. This adds `helm-release.ya?ml` (plus the `.j2` variant) to the manager file patterns.

Validated with `renovate-config-validator --strict default.json`.